### PR TITLE
Abseil fixup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,9 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
 find_package(Protobuf REQUIRED)
 
-add_subdirectory(third_party/abseil-cpp)
+if (NOT TARGET absl::base)
+  add_subdirectory(third_party/abseil-cpp)
+endif()
 add_subdirectory(third_party/pybind11)
 
 add_library(pybind11_protobuf


### PR DESCRIPTION
# Changes

When including this repostiory along protobuf which already includes abseil, we need to be careful to not redefine the abseil targets. Therefore to deal with this, if the abseil base library is already present, we avoid including it again..